### PR TITLE
refactor: improve responsive layout and typography

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -79,6 +79,15 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-body text-[16px] leading-[1.5];
+  }
+  h1 {
+    @apply font-headline text-3xl font-bold;
+  }
+  h2 {
+    @apply font-headline text-2xl font-semibold;
+  }
+  h3 {
+    @apply font-headline text-xl font-semibold;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,24 +2,28 @@
 import Image from "next/image";
 import AuthGate from "@/components/auth-gate";
 import InventoryLogger from "@/components/inventory-logger";
+import { Button } from "@/components/ui/button";
+import { LogOut } from "lucide-react";
 
 export default function Home() {
   return (
     <div className="min-h-screen w-full bg-background flex flex-col items-center p-4 sm:p-6 lg:p-8">
-      <header className="w-full max-w-5xl mb-8 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-4">
+      <header className="w-full max-w-5xl mb-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+        <div className="flex w-full flex-col items-center gap-2 sm:w-auto sm:flex-row sm:gap-4">
           <Image src="/logo.png" alt="Coastal Waste & Recycling Logo" width={150} height={45} />
-          <h1 className="text-3xl font-bold font-headline text-primary">
+          <h1 className="text-2xl font-bold font-headline text-primary sm:text-3xl">
             Coastal Inventory Logger
           </h1>
         </div>
-        {/* Optional sign-out */}
-        <a
-          href="/.auth/logout?post_logout_redirect_uri=/"
-          className="text-sm underline"
+        <Button
+          asChild
+          className="h-11 w-full px-6 shadow-sm sm:w-auto"
         >
-          Sign out
-        </a>
+          <a href="/.auth/logout?post_logout_redirect_uri=/">
+            <LogOut className="h-4 w-4" aria-hidden="true" />
+            <span>Sign out</span>
+          </a>
+        </Button>
       </header>
 
       <main className="w-full flex justify-center">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,8 +10,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        body: ["'Century Gothic'", 'sans-serif'],
-        headline: ["'Century Gothic'", 'sans-serif'],
+        body: ['Arial', 'Helvetica', 'sans-serif'],
+        headline: ['Arial', 'Helvetica', 'sans-serif'],
         code: ['monospace'],
       },
       colors: {


### PR DESCRIPTION
## Summary
- modernize typography with Arial-based stack and 1.5 line-height
- refactor header for mobile-first layout and 44px sign-out button with icon

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ad095d3dd083319d63e4af4abc723e