### PR TITLE
feat: add landing and system hours pages

### DIFF
--- a/sql/create-system-hours-table.sql
+++ b/sql/create-system-hours-table.sql
@@ -1,0 +1,13 @@
+-- sql/create-system-hours-table.sql
+-- Table for storing system hours metrics submitted from the app.
+
+CREATE TABLE Inventory.PC_SystemHours (
+    ID INT IDENTITY(1,1) PRIMARY KEY,
+    [Location] NVARCHAR(10) NOT NULL,
+    [Date] DATE NOT NULL,
+    [Metric] NVARCHAR(100) NOT NULL,
+    [Hours] DECIMAL(18,2) NOT NULL,
+    CreatedBy NVARCHAR(256) NOT NULL,
+    Source NVARCHAR(50) NOT NULL DEFAULT 'App',
+    CreatedDate DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+);

--- a/src/app/api/save-system-hours/route.ts
+++ b/src/app/api/save-system-hours/route.ts
@@ -1,0 +1,61 @@
+// src/app/api/save-system-hours/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import sql from "mssql";
+
+const poolPromise = (async () => {
+  const cs = process.env.SQL_CONNECTION_STRING;
+  if (!cs) throw new Error("SQL_CONNECTION_STRING not configured");
+  return sql.connect(cs);
+})();
+
+export async function POST(req: NextRequest) {
+  try {
+    const { userEmail, items } = await req.json();
+    if (!userEmail || !Array.isArray(items) || items.length === 0) {
+      return NextResponse.json({ ok: false, error: "Invalid payload" }, { status: 400 });
+    }
+
+    const pool = await poolPromise;
+    const tx = new sql.Transaction(pool);
+    await tx.begin();
+
+    const ps = new sql.PreparedStatement(tx);
+    ps.input("Location", sql.NVarChar);
+    ps.input("Date", sql.Date);
+    ps.input("Metric", sql.NVarChar);
+    ps.input("Hours", sql.Decimal(18, 2));
+    ps.input("CreatedBy", sql.NVarChar);
+    ps.input("Source", sql.NVarChar);
+
+    await ps.prepare(`
+      INSERT INTO Inventory.PC_SystemHours ([Location],[Date],[Metric],[Hours],CreatedBy,Source)
+      VALUES (@Location,@Date,@Metric,@Hours,@CreatedBy,@Source)
+    `);
+
+    for (const item of items) {
+      if (!item.location || !item.date || !item.metric || item.hours == null) {
+        await tx.rollback();
+        return NextResponse.json({ ok: false, error: "Missing item fields" }, { status: 400 });
+      }
+      await ps.execute({
+        Location: String(item.location),
+        Date: new Date(item.date),
+        Metric: String(item.metric),
+        Hours: Number(item.hours),
+        CreatedBy: String(userEmail),
+        Source: "App",
+      });
+    }
+
+    await ps.unprepare();
+    await tx.commit();
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (err) {
+    console.error("save-system-hours error:", err);
+    return NextResponse.json({ ok: false, error: "Server error" }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({ ok: false, error: "Method not allowed" }, { status: 405 });
+}

--- a/src/app/material-inventory/page.tsx
+++ b/src/app/material-inventory/page.tsx
@@ -1,11 +1,12 @@
-// src/app/page.tsx
+// src/app/material-inventory/page.tsx
 import Image from "next/image";
 import AuthGate from "@/components/auth-gate";
+import InventoryLogger from "@/components/inventory-logger";
 import NavigationButtons from "@/components/navigation-buttons";
 import { Button } from "@/components/ui/button";
 import { LogOut } from "lucide-react";
 
-export default function LandingPage() {
+export default function MaterialInventoryPage() {
   return (
     <div className="min-h-screen w-full bg-background flex flex-col items-center p-4 sm:p-6 lg:p-8">
       <header className="w-full max-w-5xl mb-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
@@ -28,12 +29,11 @@ export default function LandingPage() {
 
       <main className="w-full flex justify-center">
         <AuthGate>
-          <div className="text-center">
-            <p className="text-lg mb-8">Welcome to Coastal Inventory Logger. Select an option to proceed.</p>
-            <NavigationButtons />
-          </div>
+          <InventoryLogger />
         </AuthGate>
       </main>
+
+      <NavigationButtons />
     </div>
   );
 }

--- a/src/app/system-hours/page.tsx
+++ b/src/app/system-hours/page.tsx
@@ -1,11 +1,12 @@
-// src/app/page.tsx
+// src/app/system-hours/page.tsx
 import Image from "next/image";
 import AuthGate from "@/components/auth-gate";
+import SystemHoursForm from "@/components/system-hours-form";
 import NavigationButtons from "@/components/navigation-buttons";
 import { Button } from "@/components/ui/button";
 import { LogOut } from "lucide-react";
 
-export default function LandingPage() {
+export default function SystemHoursPage() {
   return (
     <div className="min-h-screen w-full bg-background flex flex-col items-center p-4 sm:p-6 lg:p-8">
       <header className="w-full max-w-5xl mb-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
@@ -28,12 +29,11 @@ export default function LandingPage() {
 
       <main className="w-full flex justify-center">
         <AuthGate>
-          <div className="text-center">
-            <p className="text-lg mb-8">Welcome to Coastal Inventory Logger. Select an option to proceed.</p>
-            <NavigationButtons />
-          </div>
+          <SystemHoursForm />
         </AuthGate>
       </main>
+
+      <NavigationButtons />
     </div>
   );
 }

--- a/src/components/navigation-buttons.tsx
+++ b/src/components/navigation-buttons.tsx
@@ -1,0 +1,25 @@
+// src/components/navigation-buttons.tsx
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Renders navigation buttons used throughout the app.
+ * "Equipment Inventory" is disabled and marked as coming soon.
+ */
+export default function NavigationButtons() {
+  return (
+    <div className="flex flex-col sm:flex-row gap-4 justify-center mt-8">
+      <Button asChild>
+        <Link href="/material-inventory">Material Inventory</Link>
+      </Button>
+      <Button asChild>
+        <Link href="/system-hours">System Hours</Link>
+      </Button>
+      <Button disabled className="bg-gray-300 text-gray-500 cursor-not-allowed" title="Coming soon">
+        Equipment Inventory
+      </Button>
+    </div>
+  );
+}

--- a/src/components/system-hours-form.tsx
+++ b/src/components/system-hours-form.tsx
@@ -1,0 +1,324 @@
+// src/components/system-hours-form.tsx
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { useState, useMemo } from "react";
+import { format, startOfToday } from "date-fns";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Loader2, PlusCircle, Trash2, Send, CheckCircle, CalendarIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useToast } from "@/hooks/use-toast";
+
+const locations = ["1001","1002","1004","1007","1012","1018","1026","1034","1035","1036","1037","1039","1041","1042"] as const;
+const metrics = ["System Runtime","Operational Downtime","Mechanical Downtime"] as const;
+
+const formSchema = z.object({
+  location: z.enum(locations, { required_error: "Please select a location." }),
+  date: z.date({ required_error: "Please select a date." }),
+  metric: z.enum(metrics, { required_error: "Please select a metric." }),
+  hours: z.coerce.number().positive({ message: "Hours must be a positive number." }),
+});
+
+export type StagedHoursItem = z.infer<typeof formSchema> & { id: string };
+
+export default function SystemHoursForm({ userEmail }: { userEmail?: string }) {
+  const [stagedItems, setStagedItems] = useState<StagedHoursItem[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submissionSuccess, setSubmissionSuccess] = useState(false);
+  const { toast } = useToast();
+
+  const defaultDate = useMemo(() => startOfToday(), []);
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      location: undefined,
+      date: defaultDate,
+      metric: undefined,
+      hours: 1,
+    },
+  });
+
+  function handleAdd(values: z.infer<typeof formSchema>) {
+    const newItem: StagedHoursItem = { ...values, id: crypto.randomUUID() };
+    setStagedItems((prev) => [...prev, newItem]);
+
+    form.reset({
+      location: values.location,
+      date: values.date,
+      metric: undefined,
+      hours: 1,
+    });
+    form.setFocus("metric");
+  }
+
+  function handleRemove(id: string) {
+    setStagedItems((prev) => prev.filter((item) => item.id !== id));
+  }
+
+  async function handleSubmitBatch() {
+    if (!userEmail) {
+      toast({
+        variant: "destructive",
+        title: "Submission Failed",
+        description: "User email not found. Cannot submit entries.",
+      });
+      return;
+    }
+    if (stagedItems.length === 0) return;
+    setIsSubmitting(true);
+    try {
+      const res = await fetch("/api/save-system-hours", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userEmail,
+          items: stagedItems.map((s) => ({
+            ...s,
+            date: s.date instanceof Date ? s.date.toISOString() : s.date,
+          })),
+        }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await res.json();
+      setStagedItems([]);
+      setSubmissionSuccess(true);
+      form.reset({ date: defaultDate, hours: 1 });
+      setTimeout(() => setSubmissionSuccess(false), 5000);
+    } catch (err) {
+      console.error("Error submitting system hours:", err);
+      toast({
+        variant: "destructive",
+        title: "Submission Failed",
+        description: "Could not save system hours. Please try again.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-5xl space-y-6">
+      <Card className="shadow-lg">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <PlusCircle className="text-primary" />
+            Log System Hours
+          </CardTitle>
+          <CardDescription>
+            Enter system hour metrics and add them to the staging table before submitting.
+          </CardDescription>
+        </CardHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleAdd)}>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 items-end">
+                <FormField
+                  control={form.control}
+                  name="location"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Location</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select location" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {locations.map((loc) => (
+                            <SelectItem key={loc} value={loc}>
+                              {loc}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="date"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-col">
+                      <FormLabel>Date</FormLabel>
+                      <Popover>
+                        <PopoverTrigger asChild>
+                          <FormControl>
+                            <Button
+                              variant="outline"
+                              className={cn(
+                                "w-full pl-3 text-left font-normal",
+                                !field.value && "text-muted-foreground"
+                              )}
+                            >
+                              {field.value ? (
+                                format(field.value, "MM/dd/yyyy")
+                              ) : (
+                                <span>Pick a date</span>
+                              )}
+                              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                            </Button>
+                          </FormControl>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                          <Calendar
+                            mode="single"
+                            selected={field.value}
+                            onSelect={field.onChange}
+                            initialFocus
+                          />
+                        </PopoverContent>
+                      </Popover>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="metric"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Metric</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select metric" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {metrics.map((m) => (
+                            <SelectItem key={m} value={m}>
+                              {m}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="hours"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Hours</FormLabel>
+                      <FormControl>
+                        <Input type="number" step="0.01" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </CardContent>
+            <CardFooter className="flex justify-end">
+              <Button type="submit">
+                <PlusCircle className="mr-2 h-4 w-4" /> Add to Staging
+              </Button>
+            </CardFooter>
+          </form>
+        </Form>
+      </Card>
+
+      {stagedItems.length > 0 && (
+        <Card className="shadow-lg">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <CheckCircle className="text-primary" />
+              Staged Entries
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Location</TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Metric</TableHead>
+                  <TableHead className="text-right">Hours</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {stagedItems.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell>{item.location}</TableCell>
+                    <TableCell>{format(item.date, "MM/dd/yyyy")}</TableCell>
+                    <TableCell>{item.metric}</TableCell>
+                    <TableCell className="text-right">{item.hours}</TableCell>
+                    <TableCell className="text-right">
+                      <Button variant="ghost" size="icon" onClick={() => handleRemove(item.id)}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+          <CardFooter className="flex justify-end">
+            <Button onClick={handleSubmitBatch} disabled={isSubmitting}>
+              {isSubmitting ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="mr-2 h-4 w-4" />
+              )}
+              Submit All
+            </Button>
+          </CardFooter>
+        </Card>
+      )}
+
+      {submissionSuccess && (
+        <div className="flex items-center text-green-600 gap-2">
+          <CheckCircle className="h-5 w-5" />
+          <span>System hours submitted successfully.</span>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add authenticated landing page with navigation
- create system hours form and API for SQL persistence
- include reusable navigation component and material inventory route

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck`
- `npm run build` *(fails: SQL_CONNECTION_STRING not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c09a333efc83319e0fcbcdb6edb72b